### PR TITLE
No parentheses without this.compileFunction

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ function TemplateFilter (inputTree, options) {
 TemplateFilter.prototype.targetExtension = 'js'
 
 TemplateFilter.prototype.processString = function (string) {
-  return 'export default ' + this.compileFunction +
-    '("' + jsStringEscape(string) + '");\n'
+  string = '"' + jsStringEscape(string) + '"'
+
+  if (this.compileFunction) {
+    string = this.compileFunction + '(' + string + ')'
+  }
+
+  return 'export default ' + string + ';\n'
 }


### PR DESCRIPTION
Otherwise, it ends up in an error:

**Uncaught SyntaxError: Unexpected token ")"**

``` javascript
define("path/template", 
  ["exports"],
  function(__exports__) {
    "use strict";
    __exports__["default"] = "<p>Hello @joliss</p>"); // <-- note the closing ")"
  });
;
```
